### PR TITLE
Fix SSL23_GET_SERVER_HELLO:unknown protocol

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -280,6 +280,10 @@ server {
 		root   {{ trim $vhost_root }};
 		include fastcgi.conf;
 		fastcgi_pass {{ trim $upstream_name }};
+		{{ else if eq $proto "https" }}
+		# passing to https://foo.example.com will give following error
+		# *1 SSL_do_handshake() failed (SSL: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol) while SSL handshaking to upstream
+		proxy_pass http://{{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
@@ -327,6 +331,10 @@ server {
 		root   {{ trim $vhost_root }};
 		include fastcgi.conf;
 		fastcgi_pass {{ trim $upstream_name }};
+		{{ else if eq $proto "https" }}
+		# passing to https://foo.example.com will give following error
+		# *1 SSL_do_handshake() failed (SSL: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol) while SSL handshaking to upstream
+		proxy_pass http://{{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}


### PR DESCRIPTION
This commit fixes the SSL23_GET_SERVER_HELLO unknown protocol error when using `docker-compose-separate-containers.yml` and redirecting to an upstream HTTPS server.

Example error:
```
nginx        | 2018/10/25 09:06:06 [error] 9#9: *1 SSL_do_handshake() failed (SSL: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol) while SSL handshaking to upstream, client: 172.18.8.224, server: whoami.my.server, request: "GET / HTTP/2.0", upstream: "https://172.27.0.3:8000/", host: "whoami.my.server"
```
Steps to reproduce:
Make sure you have the necessary `*.{crt,key,dhparam.pem}` files generated in the `./config/nginx/certs` directory. Then use following docker-compose-separate-container.yml file to do a `docker-compose up`:
```
version: "2"
services:

  nginx:
    image: nginx:alpine
    #restart: always #TODO: Remove me in production
    container_name: nginx
    ports:
      - "80:80"
      - "443:443"
    volumes:
      - /etc/nginx/conf.d
      - ./config/nginx/certs:/etc/nginx/certs

  dockergen:
    #restart: always #TODO: Remove me in production
    image: jwilder/docker-gen
    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
    volumes_from:
      - nginx
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
      - ./config/docker-gen/templates:/etc/docker-gen/templates

  whoami:
    image: jwilder/whoami
    environment:
      # Please, for the love of god, don't escape strings here!!
      # See: https://github.com/jwilder/nginx-proxy/issues/1183
      - VIRTUAL_HOST=whoami.my.server
      - VIRTUAL_PROTO=https
      - VIRTUAL_PORT=8000
```
When you visit `https://whoami.my.server`, you will see a SSL handshake error in the `nginx` container (see example error string above). While I can't find which SO answer pointed me to rewrite the `proxy_pass` URL to start with `http` instead of `https`, but this change in the `nginx.tmpl` file solved the issue for me.

Note that I am testing on "fake local domains" by manipulating the `/etc/hosts` on the client side. If this change in the code does not make sense, please let me know what I am missing.

Thanks,
-Sudarshan